### PR TITLE
Complete example configuration

### DIFF
--- a/Resources/doc/dependent_filtered_entity.rst
+++ b/Resources/doc/dependent_filtered_entity.rst
@@ -16,7 +16,7 @@ You should configure relationship between master and dependent fields for each p
 // app/config/config.yml
 
 ::
-
+shtumi_useful :
     dependent_filtered_entities:
         region_by_country:
             class: AcmeDemoBundle:Region


### PR DESCRIPTION
Add shtumi_useful, to avoid this error:

InvalidArgumentException: There is no extension able to load the configuration for "dependent_filtered_entities" (in /var/www/Symfony/app/config/config.yml). Looked for namespace "dependent_filtered_entities", found "framework", "security", "twig", "monolog", "swiftmailer", "doctrine", "assetic", "sensio_framework_extra", "jms_security_extra", "shtumi_useful", "mdw_demo", "acme_demo", "web_profiler", "sensio_distribution"
