### PR TITLE
Allow empty ajax search requests, add "Add new" button.

### DIFF
--- a/Controller/AjaxAutocompleteJSONController.php
+++ b/Controller/AjaxAutocompleteJSONController.php
@@ -31,28 +31,39 @@ class AjaxAutocompleteJSONController extends Controller
         $letters = $request->get('letters');
         $maxRows = $request->get('maxRows');
 
-        switch ($entity_inf['search']){
-            case "begins_with":
-                $like = $letters . '%';
-            break;
-            case "ends_with":
-                $like = '%' . $letters;
-            break;
-            case "contains":
-                $like = '%' . $letters . '%';
-            break;
-            default:
-                throw new \Exception('Unexpected value of parameter "search"');
-        }
 
-        $results = $em->createQuery(
-            'SELECT e.' . $entity_inf['property'] . '
-             FROM ' . $entity_inf['class'] . ' e
-             WHERE e.' . $entity_inf['property'] . ' LIKE :like
-             ORDER BY e.' . $entity_inf['property'])
-            ->setParameter('like', $like )
-            ->setMaxResults($maxRows)
-            ->getScalarResult();
+        if (trim($letters) != "") {
+            switch ($entity_inf['search']){
+                case "begins_with":
+                    $like = $letters . '%';
+                break;
+                case "ends_with":
+                    $like = '%' . $letters;
+                break;
+                case "contains":
+                    $like = '%' . $letters . '%';
+                break;
+                default:
+                    throw new \Exception('Unexpected value of parameter "search"');
+            } 
+            
+            $results = $em->createQuery(
+                'SELECT e.' . $entity_inf['property'] . '
+                 FROM ' . $entity_inf['class'] . ' e
+                 WHERE e.' . $entity_inf['property'] . ' LIKE :like
+                 ORDER BY e.' . $entity_inf['property'])
+                ->setParameter('like', $like )
+                ->setMaxResults($maxRows)
+                ->getScalarResult();        
+        } else {
+            // Allow all search / empty search.
+            $results = $em->createQuery(
+                'SELECT e.' . $entity_inf['property'] . '
+                 FROM ' . $entity_inf['class'] . ' e
+                 ORDER BY e.' . $entity_inf['property'])
+                ->setMaxResults($maxRows)
+                ->getScalarResult();                  
+        }
 
         $res = array();
         foreach ($results AS $r){

--- a/Resources/views/fields.html.twig
+++ b/Resources/views/fields.html.twig
@@ -30,7 +30,7 @@
                         }
                     });
                 },
-                minLength: 2,
+                minLength: 1,
                 open: function() {
                     $( this ).removeClass( "ui-corner-all" ).addClass( "ui-corner-top" );
                 },
@@ -60,7 +60,34 @@
     </style>
 
 
-    {{ form_widget(form) }}
+    {% if sonata_admin.field_description %}
+        <div id="field_container_{{ id }}" class="field-container">
+            <span id="field_widget_{{ id }}" >
+                {{ form_widget(form) }}
+            </span>
+
+            <span id="field_actions_{{ id }}" class="field-actions">
+                {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+                    <a
+                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
+                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                        class="btn sonata-ba-action"
+                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        >
+                        <i class="icon-plus"></i>
+                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                    </a>
+                {% endif %}
+            </span>
+
+            <div style="display: none" id="field_dialog_{{ id }}"></div>
+        </div>
+
+        {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_many_association_script.html.twig' %}
+    
+    {% else %}
+        {{ form_widget(form) }}
+    {% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
Hi,

The Following Pull request adds 2 features to the Ajax feature:
1.) Adds the capability to do "empty" search request (by inserting a space).
2.) Adds a "Add new" button to the ajax form field.

I've tested this, but i'm very new to Symfony2/Twig and so on.

Thanks for this very useful bundle :-)