### PR TITLE
fixed incorrect replaced method name

### DIFF
--- a/Controller/DependentFilteredEntityController.php
+++ b/Controller/DependentFilteredEntityController.php
@@ -40,7 +40,7 @@ class DependentFilteredEntityController extends Controller
 
 
         if (null !== $entity_inf['callback']) {
-            $repository = $qb->getManager()->getRepository($entity_inf['class']);
+            $repository = $qb->getEntityManager()->getRepository($entity_inf['class']);
 
             if (!method_exists($repository, $entity_inf['callback'])) {
                 throw new \InvalidArgumentException(sprintf('Callback function "%s" in Repository "%s" does not exist.', $entity_inf['callback'], get_class($repository)));


### PR DESCRIPTION
During renaming `getEntityManager()` to `getManager()` for sf2.3 compatibility, accidentally was replaced consonant method from `QueryBuilder`. Unlike Symfony's `Controller` class, [`Doctrine\ORM\QueryBuilder`](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/QueryBuilder.php) still has `getEntityManager` method only.
