### PR TITLE
Make EntityToId Data transformer reverse transform independent from entity pk name,

### DIFF
--- a/Controller/DependentFilteredEntityController.php
+++ b/Controller/DependentFilteredEntityController.php
@@ -24,6 +24,10 @@ class DependentFilteredEntityController extends Controller
         $parent_id    = $request->get('parent_id');
         $empty_value  = $request->get('empty_value');
 
+        if (empty($parent_id)) {
+           $parent_id = null;
+        }
+
         $entities = $this->get('service_container')->getParameter('shtumi.dependent_filtered_entities');
         $entity_inf = $entities[$entity_alias];
 

--- a/Controller/DependentFilteredEntityController.php
+++ b/Controller/DependentFilteredEntityController.php
@@ -58,7 +58,17 @@ class DependentFilteredEntityController extends Controller
         $results = $qb->getQuery()->getResult();
 
         if (empty($results)) {
-            return new Response('<option value="">' . $translator->trans($entity_inf['no_result_msg']) . '</option>');
+            // Executes fallback query to get all results
+            $qb = $this->getDoctrine()
+                       ->getRepository($entity_inf['class'])
+                       ->createQueryBuilder('e');
+
+            if (null !== $entity_inf['callback']) {
+                $repository = $qb->getEntityManager()->getRepository($entity_inf['class']);
+                $repository->$entity_inf['callback']($qb);
+            }
+
+            $results = $qb->getQuery()->getResult();
         }
 
         $html = '';

--- a/Form/DataTransformer/EntityToIdTransformer.php
+++ b/Form/DataTransformer/EntityToIdTransformer.php
@@ -48,7 +48,15 @@ class EntityToIdTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($id, 'numeric' . $id);
         }
 
-        $entity = $this->em->getRepository($this->class)->findOneById($id);
+        $pkColumn = $this->em
+                         ->getClassMetadata($this->class)
+                         ->getSingleIdentifierColumnName();
+
+        $pkFieldName = $this->em
+                             ->getClassMetadata($this->class)
+                             ->getFieldForColumn($pkColumn);
+
+        $entity = $this->em->getRepository($this->class)->findOneBy(array($pkFieldName => $id));
 
         if ($entity === null) {
             throw new TransformationFailedException(sprintf('The entity with key "%s" could not be found', $id));


### PR DESCRIPTION
Hi.

I've been using this bundle and recently had some problems with the EntityToIdTransformer, the reverse tranformation is assuming that the primary key field name will always be "id".
